### PR TITLE
Making the grunt task stop (with grunt.warning) when there is a faillure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,11 @@ module.exports = function(grunt) {
           'test/expected/one.min.json': ['test/fixtures/one.json'],
           'test/expected/all.min.json': ['test/fixtures/*.json']
         }
+      },
+      fail: {
+        files: {
+          'test/expected/fail.min.json': ['test/fixtures/failure/fail.json']
+        }
       }
     },
     jshint: {
@@ -29,5 +34,6 @@ module.exports = function(grunt) {
   });
   grunt.loadTasks('tasks');
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.registerTask('default', ['jshint', 'minjson']);
+  grunt.registerTask('default', ['jshint', 'minjson:all']);
+  grunt.registerTask('fail', ['minjson:fail']);
 };

--- a/tasks/minjson.js
+++ b/tasks/minjson.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
         grunt.log.writeln('File "' + dest + '" created: ' + maxmin(uncompressedString, compressedString));
       } else {
         // display errors
-        errors.forEach(function(msg) { grunt.log.error(msg); });
+        grunt.fail.warn("\n"+ errors.join('\n') +"\n" , 1);
       }
     });
   });

--- a/test/fixtures/failure/fail.json
+++ b/test/fixtures/failure/fail.json
@@ -1,0 +1,3 @@
+{
+  "failing file": no quote
+}


### PR DESCRIPTION
Hi, using the tool, I have seen that the task don't fail when there is an error in the minification.
This is why I have created this (simple) pull request.

Let me know if something is not right.
